### PR TITLE
Add migration script for existing 17 project photos

### DIFF
--- a/MIGRATE_EXISTING_PHOTOS.sql
+++ b/MIGRATE_EXISTING_PHOTOS.sql
@@ -1,0 +1,53 @@
+-- Migrate Existing Project Photos to Database
+-- Run this AFTER running PROJECT_PHOTOS_SETUP.sql
+
+-- ============================================
+-- Insert existing 17 project photos
+-- ============================================
+
+-- These photos are already in your /images/projects/ folder
+-- This script adds them to the database so you can manage them via admin panel
+
+INSERT INTO project_photos (title, description, image_url, display_order, is_active) VALUES
+('Cable Installation', 'Underground cable installation and laying', '/images/projects/cable-installation.jpg', 1, true),
+('Equipment Setup', 'Electrical equipment setup and configuration', '/images/projects/equipment-setup.jpg', 2, true),
+('Concrete Foundation', 'Concrete block foundation work', '/images/projects/concrete-blocks.jpg', 3, true),
+('Control Panel', 'Electrical control panel installation', '/images/projects/control-panel.jpg', 4, true),
+('11kV Switchgear', '11kV switchgear installation', '/images/projects/11swg.jpg', 5, true),
+('11kV Transformer', '11kV transformer installation and setup', '/images/projects/11tr.jpg', 6, true),
+('33kV Cable', '33kV high voltage cable installation', '/images/projects/33cable.jpg', 7, true),
+('33kV Switchgear', '33kV switchgear installation and commissioning', '/images/projects/33swg.jpg', 8, true),
+('33kV Transformer', '33kV transformer installation project', '/images/projects/33tr.jpg', 9, true),
+('Civil Works Phase 1', 'Civil construction and foundation work', '/images/projects/civil1.JPG', 10, true),
+('Cable Jointing Phase 1', 'Underground cable jointing work', '/images/projects/jointing1.JPG', 11, true),
+('Cable Jointing Phase 2', 'Cable jointing and termination process', '/images/projects/jointing2.JPG', 12, true),
+('Cable Pulling Phase 1', 'Cable pulling through conduits', '/images/projects/pulling1.jpg', 13, true),
+('Cable Pulling Phase 2', 'Underground cable pulling operations', '/images/projects/pulling2.JPG', 14, true),
+('Termination Phase 1', 'Cable termination and connection work', '/images/projects/termination1.JPG', 15, true),
+('Termination Phase 2', 'Final cable termination and testing', '/images/projects/termination2.JPG', 16, true),
+('Equipment Testing', 'Testing and commissioning of electrical equipment', '/images/projects/testing1.JPG', 17, true);
+
+-- ============================================
+-- Verify the migration
+-- ============================================
+
+-- Check that all 17 photos were inserted
+SELECT COUNT(*) as total_photos FROM project_photos;
+
+-- View all photos ordered by display_order
+SELECT display_order, title, is_active FROM project_photos ORDER BY display_order;
+
+-- ============================================
+-- MIGRATION COMPLETE!
+-- ============================================
+
+-- After running this:
+-- 1. Your 17 existing photos are now in the database
+-- 2. They will appear in the admin Gallery tab
+-- 3. You can now edit titles, descriptions, reorder, or delete them
+-- 4. The public gallery will show these photos from the database
+-- 5. You can add new photos through the admin panel
+
+-- Note: These photos still exist in /images/projects/ folder
+-- The database just references them by URL
+-- If you want to delete a photo completely, also remove it from the folder

--- a/PHOTO_MIGRATION_GUIDE.md
+++ b/PHOTO_MIGRATION_GUIDE.md
@@ -1,0 +1,300 @@
+# Migrating Existing Photos to Database
+
+Your portfolio already has 17 project photos in the `/images/projects/` folder. This guide shows you how to migrate them to the database so you can manage them through the admin panel.
+
+## 🚀 Quick Migration (2 Steps)
+
+### Step 1: Run Setup Script (if not done)
+
+If you haven't already:
+```sql
+-- In Supabase SQL Editor
+Run: PROJECT_PHOTOS_SETUP.sql
+```
+
+### Step 2: Migrate Existing Photos
+
+```sql
+-- In Supabase SQL Editor
+Run: MIGRATE_EXISTING_PHOTOS.sql
+```
+
+✅ **Done!** Your 17 photos are now in the database.
+
+---
+
+## 📸 What Happens After Migration
+
+### In Admin Panel (`/admin` → Gallery tab):
+
+**You'll see all 17 photos with:**
+- Default titles (based on filenames)
+- Order from 1-17
+- All set to "Active" (visible)
+- Ready to manage!
+
+### What You Can Do Now:
+
+1. **Edit Titles**
+   - Click on a photo in admin
+   - Current: "Cable Installation"
+   - Change to: "Main Distribution Cable - Phase 1"
+
+2. **Add Descriptions**
+   - Currently: Basic descriptions
+   - Add more details for each photo
+   - Descriptions show on hover
+
+3. **Reorder Photos**
+   - Use ⬆️⬇️ buttons
+   - Arrange by project phase
+   - Or group by equipment type
+
+4. **Hide/Show Photos**
+   - Click 👁️ to hide outdated photos
+   - Keep in database but remove from gallery
+   - Show again anytime
+
+5. **Delete Photos**
+   - Remove photos you don't need
+   - Deletes from database only
+   - File still exists in `/images/projects/`
+
+6. **Add New Photos**
+   - Upload through admin panel
+   - New photos saved to Supabase Storage
+   - Appear alongside migrated photos
+
+---
+
+## 🔍 Current Photos Being Migrated
+
+| # | Title | Filename |
+|---|-------|----------|
+| 1 | Cable Installation | cable-installation.jpg |
+| 2 | Equipment Setup | equipment-setup.jpg |
+| 3 | Concrete Foundation | concrete-blocks.jpg |
+| 4 | Control Panel | control-panel.jpg |
+| 5 | 11kV Switchgear | 11swg.jpg |
+| 6 | 11kV Transformer | 11tr.jpg |
+| 7 | 33kV Cable | 33cable.jpg |
+| 8 | 33kV Switchgear | 33swg.jpg |
+| 9 | 33kV Transformer | 33tr.jpg |
+| 10 | Civil Works Phase 1 | civil1.JPG |
+| 11 | Cable Jointing Phase 1 | jointing1.JPG |
+| 12 | Cable Jointing Phase 2 | jointing2.JPG |
+| 13 | Cable Pulling Phase 1 | pulling1.jpg |
+| 14 | Cable Pulling Phase 2 | pulling2.JPG |
+| 15 | Termination Phase 1 | termination1.JPG |
+| 16 | Termination Phase 2 | termination2.JPG |
+| 17 | Equipment Testing | testing1.JPG |
+
+---
+
+## 📝 Titles & Descriptions Added
+
+I've added descriptive titles and brief descriptions for each photo:
+
+**Example:**
+- **Title:** "Cable Installation"
+- **Description:** "Underground cable installation and laying"
+
+**You can customize these:**
+1. Go to admin → Gallery tab
+2. Photos now appear in grid
+3. Edit titles/descriptions as needed
+4. Changes save automatically
+
+---
+
+## 🎯 Before vs After Migration
+
+### Before Migration:
+
+```
+❌ Photos hardcoded in component
+❌ Can't change order without code edits
+❌ Can't add descriptions
+❌ Can't hide photos
+❌ Must deploy code to add/remove photos
+```
+
+### After Migration:
+
+```
+✅ Photos in database
+✅ Reorder with ⬆️⬇️ buttons (no code!)
+✅ Add/edit descriptions anytime
+✅ Show/hide photos instantly
+✅ Add new photos via admin panel
+✅ Delete old photos via admin panel
+✅ No deployments needed for changes
+```
+
+---
+
+## 🔧 Verification Steps
+
+After running the migration:
+
+### 1. Check Database
+```sql
+-- Should return 17
+SELECT COUNT(*) FROM project_photos;
+
+-- View all photos
+SELECT display_order, title, is_active
+FROM project_photos
+ORDER BY display_order;
+```
+
+### 2. Check Admin Panel
+1. Login to `/admin`
+2. Go to Gallery tab
+3. You should see 17 photos in grid
+4. All should have green "Active" badges
+5. Numbered #1 through #17
+
+### 3. Check Public Gallery
+1. Visit your main site `/`
+2. Scroll to Projects section
+3. Photos should appear in carousel
+4. Should show 17 photos total
+5. Hover to see descriptions
+
+---
+
+## 🎨 Customization Ideas
+
+Now that photos are in the database, you can:
+
+### Better Titles
+**Current:** "Cable Pulling Phase 1"
+**Better:** "Underground HV Cable Pulling - Main Distribution Line"
+
+### Detailed Descriptions
+**Current:** "Cable pulling through conduits"
+**Better:** "33kV underground cable pulling through pre-installed HDPE conduits for the main distribution line, completed Q2 2024"
+
+### Logical Grouping
+Reorder by:
+1. **Project Phase:**
+   - Civil Works (1-3)
+   - Cable Installation (4-8)
+   - Testing & Commissioning (9-12)
+   - Switchgear Installation (13-17)
+
+2. **Equipment Type:**
+   - Transformers (1-4)
+   - Switchgear (5-8)
+   - Cables (9-14)
+   - Testing (15-17)
+
+3. **Chronological:**
+   - Oldest projects first
+   - Recent projects last
+
+---
+
+## 💡 Best Practices
+
+### After Migration:
+
+1. **Review Titles** (30 mins)
+   - Make them descriptive
+   - Add project names/dates
+   - Use consistent naming
+
+2. **Add Better Descriptions** (1 hour)
+   - Technical details
+   - Project context
+   - Completion dates
+   - Key achievements
+
+3. **Optimize Order** (15 mins)
+   - Best photos first
+   - Logical flow
+   - Show variety
+
+4. **Quality Check** (15 mins)
+   - Hide low-quality photos
+   - Delete duplicates
+   - Verify all visible
+
+---
+
+## 🚨 Important Notes
+
+### About File Locations:
+
+**Migrated Photos (17 existing):**
+- **Location:** `/images/projects/` folder
+- **In Database:** URL reference only
+- **If you delete from admin:** Removes from database, file stays in folder
+- **To fully delete:** Also remove from `/images/projects/` folder
+
+**New Uploaded Photos:**
+- **Location:** Supabase Storage bucket
+- **In Database:** URL + metadata
+- **If you delete from admin:** Removes from both storage and database
+- **Fully deleted:** Nothing to clean up
+
+### Migration is Safe:
+
+- ✅ Original files untouched
+- ✅ Website keeps working during migration
+- ✅ Can revert by clearing database
+- ✅ No data loss risk
+
+---
+
+## 🔄 If You Need to Re-migrate
+
+If something goes wrong:
+
+### Clear and Re-run:
+```sql
+-- Delete all photos from database
+DELETE FROM project_photos;
+
+-- Re-run migration
+Run: MIGRATE_EXISTING_PHOTOS.sql again
+```
+
+### Reset to Fresh State:
+```sql
+-- Remove specific photos
+DELETE FROM project_photos WHERE display_order <= 17;
+
+-- Or delete by URL pattern
+DELETE FROM project_photos WHERE image_url LIKE '/images/projects/%';
+```
+
+---
+
+## ✅ Migration Checklist
+
+- [ ] Run PROJECT_PHOTOS_SETUP.sql (one-time setup)
+- [ ] Run MIGRATE_EXISTING_PHOTOS.sql (migration)
+- [ ] Verify 17 photos in database
+- [ ] Check admin Gallery tab shows all photos
+- [ ] Verify public gallery displays photos
+- [ ] Edit titles for clarity
+- [ ] Add detailed descriptions
+- [ ] Reorder photos logically
+- [ ] Hide any unwanted photos
+- [ ] Test uploading a new photo
+- [ ] Test deleting a photo
+
+---
+
+## 🎉 Success!
+
+After migration, you have:
+- ✅ 17 existing photos managed through admin
+- ✅ Ability to add unlimited new photos
+- ✅ Complete control over gallery
+- ✅ No code changes needed
+- ✅ Professional photo management system
+
+**Next step:** Login to admin and start customizing your gallery!


### PR DESCRIPTION
Created migration system to move existing hardcoded photos into the database for admin panel management.

New files:
1. MIGRATE_EXISTING_PHOTOS.sql - SQL script to insert all 17 existing project photos from /images/projects/ folder into the database

2. PHOTO_MIGRATION_GUIDE.md - Complete guide explaining:
   - How to run the migration (2 simple steps)
   - What happens after migration
   - Before/after comparison
   - Customization ideas
   - How to edit titles and descriptions
   - Verification steps

Migration includes:
- All 17 existing photos with descriptive titles
- Proper ordering (1-17)
- Professional descriptions for each photo
- All set to active by default
- Categories: cables, transformers, switchgear, civil, testing

After migration, admin can:
✅ Edit all photo titles and descriptions
✅ Reorder photos visually
✅ Hide/show any photo
✅ Delete unwanted photos
✅ Add new photos
✅ Manage entire gallery without code changes

Photos remain in /images/projects/ folder, database stores metadata and URL references for admin panel management.

To use:
1. Run PROJECT_PHOTOS_SETUP.sql (one-time)
2. Run MIGRATE_EXISTING_PHOTOS.sql (migration)
3. Check admin Gallery tab - see all 17 photos
4. Start managing gallery!

https://claude.ai/code/session_01QL8Xd3Ed4JPndzJDhWPk3U