### PR TITLE
Fix certificate image display with correct filenames

### DIFF
--- a/src/data/certificateData.ts
+++ b/src/data/certificateData.ts
@@ -17,13 +17,13 @@ export const otherCertifications: Certificate[] = [
     id: 9,
     title: "Certified Green Project Manager (GPM-b™)",
     date: "October 2025",
-    imageUrl: "/images/certifications/gpm-b-cert.png"
+    imageUrl: "/images/certifications/gpm-b-badge.png"
   },
   {
     id: 1,
     title: "HashiCorp Certified: Terraform Associate (003)",
     date: "Nov 2023",
-    imageUrl: "https://images.credly.com/size/340x340/images/85b9cfc4-257a-4742-878c-4f7ab4a2631b/image.png"
+    imageUrl: "/images/certifications/hashi-corp-terraform.png"
   },
   {
     id: 3,


### PR DESCRIPTION
Updated image paths to match uploaded files:
- GPM-b: Changed from gpm-b-cert.png to gpm-b-badge.png
- HashiCorp: Changed from Credly URL to local hashi-corp-terraform.png

User uploaded these files via GitHub web interface but filenames didn't match the code expectations. Now using correct local paths.

All certificate images should now display properly:
- GPM-b™ badge (October 2025) - circular teal badge
- HashiCorp Terraform badge (Nov 2023) - local file

https://claude.ai/code/session_01QL8Xd3Ed4JPndzJDhWPk3U