### PR TITLE
Reverse project photos order to show newest first

### DIFF
--- a/src/components/ProjectImages.tsx
+++ b/src/components/ProjectImages.tsx
@@ -52,7 +52,7 @@ const ProjectImages = () => {
         .from('project_photos')
         .select('*')
         .eq('is_active', true)
-        .order('display_order', { ascending: true });
+        .order('display_order', { ascending: false });
 
       if (error) {
         console.error("Error fetching photos:", error);

--- a/src/components/admin/PhotoGallery.tsx
+++ b/src/components/admin/PhotoGallery.tsx
@@ -56,7 +56,7 @@ export const PhotoGallery = () => {
       const { data, error } = await supabase
         .from('project_photos')
         .select('*')
-        .order('display_order', { ascending: true });
+        .order('display_order', { ascending: false });
 
       if (error) throw error;
       return data as ProjectPhoto[];


### PR DESCRIPTION
Changed the display order for project photos from ascending to descending so that newly uploaded photos appear at the beginning of the gallery.

Changes:
- PhotoGallery.tsx: Changed order from ascending to descending
  * Newest uploads now appear first in admin panel
  * Manual reordering with up/down arrows still works
  * New photos get highest display_order value

- ProjectImages.tsx: Changed order from ascending to descending
  * Public gallery carousel now shows newest photos first
  * Maintains consistency with admin panel ordering

This ensures that all future photo additions automatically appear at the top of both the admin gallery and the public-facing project carousel.

https://claude.ai/code/session_01QL8Xd3Ed4JPndzJDhWPk3U